### PR TITLE
[BUGFIX] Initialise TSFE properly

### DIFF
--- a/Classes/Utility/EidUtility.php
+++ b/Classes/Utility/EidUtility.php
@@ -29,7 +29,7 @@ class EidUtility
             $controller->initTemplate();
         }
 
-        if (!is_array($controller->config)) {
+        if (!empty($controller->config)) {
             $controller->getConfigArray();
         }
 

--- a/Classes/Utility/EidUtility.php
+++ b/Classes/Utility/EidUtility.php
@@ -29,7 +29,7 @@ class EidUtility
             $controller->initTemplate();
         }
 
-        if (!empty($controller->config)) {
+        if (empty($controller->config)) {
             $controller->getConfigArray();
         }
 


### PR DESCRIPTION
In TYPO3 6.2, the $config property in TypoScriptFrontendController defaulted to an empty string.
In TYPO3 7.6, this is changed to an empty array.

This caused the getConfigArray check to fail in the EidUtility, which caused all sort of problems.