### PR TITLE
Compile IfPropertyHasErrorViewHelper with renderStatic

### DIFF
--- a/Classes/ViewHelper/Form/IfPropertyHasErrorViewHelper.php
+++ b/Classes/ViewHelper/Form/IfPropertyHasErrorViewHelper.php
@@ -4,9 +4,8 @@ namespace Keizer\KoningLibrary\ViewHelper\Form;
 
 use Closure;
 use Exception;
-use TYPO3\CMS\Fluid\ViewHelpers\CoreFormViewHelper;
-use TYPO3\CMS\Form\ViewHelpers\CoreFormViewHelper as FormViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
 /**
@@ -14,6 +13,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IfPropertyHasErrorViewHelper extends AbstractConditionViewHelper
 {
+    use CompileWithRenderStatic;
+
     /**
      * Constructor
      */


### PR DESCRIPTION
Also remove unresolved imports.

This change is required to ensure the viewhelper is called correctly
after a 'Flush all caches' action.

Tested on TYPO3 9.5.21